### PR TITLE
Fixed check for None in get_band_energies.

### DIFF
--- a/hotbit/aseinterface.py
+++ b/hotbit/aseinterface.py
@@ -498,7 +498,7 @@ class Hotbit(Output):
         rs:        use 'kappa'- or 'k'-points in reciprocal space
         h1:        Add Coulomb part to hamiltonian matrix. Required for consistent use of SCC.
         '''
-        if kpts==None:
+        if kpts is None:
             e = self.st.e * Hartree
         else:
             if rs=='k':


### PR DESCRIPTION
The old version causes problems when kpts is a numpy array, since it is not clear whether the comparison operation == is to be applied to any or all of the elements in the array. Actually the intended check is whether kpts itself is set to None.